### PR TITLE
fixed 'et al.' appearing at the top of dataset pages

### DIFF
--- a/ckanext/doi/theme/templates/package/read_base.html
+++ b/ckanext/doi/theme/templates/package/read_base.html
@@ -5,7 +5,7 @@
     {% if pkg['doi_status'] %}
     <meta name="citation_doi" content="doi:{{ pkg['doi'] }}" />
     <meta name="citation_title" content="{{ pkg['title'] }}" />
-    <meta name="citation_author" content="{{ pkg['author'] }}" />
+    <meta name="citation_author" content="{{ pkg['all_authors'] }}" />
     <meta name="citation_online_date" content="{{ pkg['doi_date_published'] }}" />
     <meta name="citation_publisher" content="{{ pkg['doi_publisher'] }}" />
     {% endif %}


### PR DESCRIPTION
citation_author meta tag was using the 'author' entry from pkg_dict, which may contain html (as in ckanext-nhm) - all_authors should just be a basic list of author names.