### PR TITLE
changed doi.org links to use https and removed dx. subdomain

### DIFF
--- a/ckanext/doi/theme/templates/doi/snippets/package_citation.html
+++ b/ckanext/doi/theme/templates/doi/snippets/package_citation.html
@@ -15,7 +15,7 @@ Renders a citation for a package
                     {{ site_title }}.
                 {% endif %}
             {% block citation_link %}
-                <a href="http://dx.doi.org/{{ pkg_dict['doi'] }}" target="_blank">http://dx.doi.org/{{ pkg_dict['doi'] }}</a></p>
+                <a href="https://doi.org/{{ pkg_dict['doi'] }}" target="_blank">https://doi.org/{{ pkg_dict['doi'] }}</a></p>
             {% endblock %}
             </p>
 


### PR DESCRIPTION
closes NaturalHistoryMuseum/ckanext-nhm#341