### PR TITLE
Swap http://dx.doi.org for https://doi.org as it is preferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CKAN extension for assigning a digital object identifier (DOI) to datasets, usin
 
 When a new dataset is created it is assigned a new DOI. This DOI will be in the format:
  
-http://dx.doi.org/[prefix]/[random 7 digit integer]
+https://doi.org/[prefix]/[random 7 digit integer]
 
 If the new dataset is active and public, the DOI and metadata will be registered with DataCite.
  

--- a/ckanext/doi/theme/templates/doi/snippets/package_citation.html
+++ b/ckanext/doi/theme/templates/doi/snippets/package_citation.html
@@ -15,7 +15,7 @@ Renders a citation for a package
                     {{ site_title }}.
                 {% endif %}
             {% block citation_link %}
-                <a href="http://dx.doi.org/{{ pkg_dict['doi'] }}" target="_blank">http://dx.doi.org/{{ pkg_dict['doi'] }}</a></p>
+                <a href="https://doi.org/{{ pkg_dict['doi'] }}" target="_blank">https://doi.org/{{ pkg_dict['doi'] }}</a></p>
             {% endblock %}
             </p>
 


### PR DESCRIPTION
Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/156
 