### PR TITLE
Always return doi prefix from conf, not deprecated test prefix

### DIFF
--- a/ckanext/doi/datacite.py
+++ b/ckanext/doi/datacite.py
@@ -25,10 +25,17 @@ def get_test_mode():
 def get_prefix():
     """
     Get the prefix to use for DOIs
-    @return: test prefix if we're in test mode, otherwise config prefix setting
+    @return: config prefix setting
     """
+    prefix = config.get("ckanext.doi.prefix")
 
-    return TEST_PREFIX if get_test_mode() else config.get("ckanext.doi.prefix")
+    if prefix == None:
+      raise TypeError('You must set the ckanext.doi.prefix config value')
+
+    if prefix == TEST_PREFIX:
+      raise ValueError('The test prefix ' + TEST_PREFIX + ' has been retired, use a prefix defined in your datacite test account')
+
+    return prefix
 
 
 def get_endpoint():


### PR DESCRIPTION
Fixes #35

Not sure how much it's worth doing these type checks, but thought I'd throw them in anyway.