### PR TITLE
Datacite 1.1.2

### DIFF
--- a/ckanext/doi/lib/api.py
+++ b/ckanext/doi/lib/api.py
@@ -121,10 +121,10 @@ class DataciteClient:
         :param xml_dict: the metadata as an xml dict (generated from build_xml_dict)
         :return:
         '''
-        xml_dict['identifier'] = {
+        xml_dict['identifiers'] = [{
             'identifierType': 'DOI',
             'identifier': doi
-        }
+        }]
 
         # check that the data is valid, this will raise a JSON schema exception if there are issues
         schema42.validator.validate(xml_dict)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
 # install from setup.py
 .
-
-# dev overrides/additional libraries
-# schema42 not released on pypi, so get datacite lib from github (version number is the same), we
-# want this specific commit because it includes lxml>=4.3.5 which is compatible with ckan core's
-# required version
-git+https://github.com/inveniosoftware/datacite.git@454eed812eac77121fe8fd21ac26b8d60dc1d7d7

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        # force the base same version as ckan (the datacite github repo installs a higher version)
-        'lxml~=4.4.0',
-        'requests',
+        'datacite==1.1.2',
         'xmltodict==0.12.0',
         'jsonschema==3.0.0',
-        # force the same base version as ckan
-        'python-dateutil~=2.8.0',
     ],
     entry_points= \
         '''


### PR DESCRIPTION
This PR set datacite v1.2.2 as requirement and make the produced XML compliant with schema42.

Fix #53.