### PR TITLE
Add initdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Path variables used below:
   ckan.plugins = ... doi
   ```
 
+6. Initialize the database
+
+ ```bash
+ ckan -c $CONFIG_FILE doi initdb
+ ```
+
 
 # Configuration
 


### PR DESCRIPTION
`README.md` does not mention `initdb`, which is critical to set up ckanext-doi.