### PR TITLE
Update badges and logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # ckanext-doi
 
-[![Tests](https://img.shields.io/github/workflow/status/NaturalHistoryMuseum/ckanext-doi/Tests?style=flat-square)](https://github.com/NaturalHistoryMuseum/ckanext-doi/actions/workflows/main.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/NaturalHistoryMuseum/ckanext-doi/main.yml?style=flat-square)](https://github.com/NaturalHistoryMuseum/ckanext-doi/actions/workflows/main.yml)
 [![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-doi/main?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-doi)
 [![CKAN](https://img.shields.io/badge/ckan-2.9.7-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 [![Python](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue.svg?style=flat-square)](https://www.python.org/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--header-start-->
-<img src=".github/nhm-logo.svg" align="left" width="150px" height="100px" hspace="40"/>
+<img src="https://github.com/NaturalHistoryMuseum/ckanext-doi/blob/main/.github/nhm-logo.svg" align="left" width="150px" height="100px" hspace="40"/>
 
 # ckanext-doi
 


### PR DESCRIPTION
Fix github actions badge (see issue 8671 in badges/shields) and use a full https link for the logo so that it works on PyPI as well.