### PR TITLE
[97] Fixes schemeURI is never generated in the XML payload

### DIFF
--- a/ckanext/doi/lib/xml_utils.py
+++ b/ckanext/doi/lib/xml_utils.py
@@ -74,6 +74,6 @@ def create_contributor(
                 'nameIdentifierScheme': _id['scheme'],
             }
             if 'scheme_uri' in _id:
-                id_dict['schemeUri'] = _id['scheme_uri']
+                id_dict['schemeURI'] = _id['scheme_uri']
             contributor['nameIdentifiers'].append(id_dict)
     return contributor


### PR DESCRIPTION
This PR fixes the missing schemeURI attribute in datacite XML as explained in the issue #97 