### PR TITLE
#Fixes #100: Update to schema43

### DIFF
--- a/ckanext/doi/lib/api.py
+++ b/ckanext/doi/lib/api.py
@@ -12,7 +12,7 @@ import xmltodict
 from ckan.common import asbool
 from ckan.plugins import toolkit
 from ckanext.doi.model.crud import DOIQuery
-from datacite import DataCiteMDSClient, schema42
+from datacite import DataCiteMDSClient, schema43
 from datacite.errors import DataCiteError, DataCiteNotFoundError
 from datetime import datetime as dt
 
@@ -139,9 +139,9 @@ class DataciteClient:
         xml_dict['identifiers'] = [{'identifierType': 'DOI', 'identifier': doi}]
 
         # check that the data is valid, this will raise a JSON schema exception if there are issues
-        schema42.validator.validate(xml_dict)
+        schema43.validator.validate(xml_dict)
 
-        xml_doc = schema42.tostring(xml_dict)
+        xml_doc = schema43.tostring(xml_dict)
         # create the metadata on datacite
         self.client.metadata_post(xml_doc)
 
@@ -170,7 +170,7 @@ class DataciteClient:
         if posted_xml is None or posted_xml.strip() == '':
             return False
         posted_xml_dict = dict(xmltodict.parse(posted_xml).get('resource', {}))
-        new_xml_dict = dict(xmltodict.parse(schema42.tostring(xml_dict))['resource'])
+        new_xml_dict = dict(xmltodict.parse(schema43.tostring(xml_dict))['resource'])
         if 'identifier' in posted_xml_dict:
             del posted_xml_dict['identifier']
         has_dates = 'dates' in posted_xml_dict and 'date' in posted_xml_dict['dates']


### PR DESCRIPTION
@alycejenni From my tests this PR covers what is needed to update to the last available schema43 (@ datacite api wrapper). In case I forget something I'm happy about your guidance and working on it.

**Overview**

https://schema.datacite.org/meta/kernel-4.3/

> Changes
Addition of optional “affiliationIdentifier”, “affiliationIdentifierScheme”, and “schemeURI” for affiliation
Addition of optional “schemeURI” for funderIdentifier
Addition of “ROR” to allowed values for funderIdentifierType

Since schema43 affilations can look like

```
<contributor contributorType="Researcher">
      <contributorName>Huber-Bert, Manfred</contributorName>
      <affiliation affiliationIdentifier="https://ror.org/idkfa3" affiliationIdentifierScheme="ROR" schemeURI="https://ror.org">Something</affiliation>
  </contributor>
```

Instead of the following with scheme42
```
<affiliation>Something</affiliation>
```

Hence, my feature request is to upgrade the plugin to use schema43

**Possible Solutions**
From my tests it works to just bump to schema43 and use it in later code lines as proposed by the PR

https://github.com/NaturalHistoryMuseum/ckanext-doi/blob/59942cf069c2f867459c1396bd9127cb644d7436/ckanext/doi/lib/api.py#L15

