### PR TITLE
Refactor DOIPlugin to only flash success messages in blueprint views

### DIFF
--- a/ckanext/doi/plugin.py
+++ b/ckanext/doi/plugin.py
@@ -89,13 +89,19 @@ class DOIPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
                 # metadata gets created before minting
                 client.set_metadata(doi.identifier, xml_dict)
                 client.mint_doi(doi.identifier, package_id)
-                toolkit.h.flash_success('DataCite DOI created')
+                if hasattr(toolkit.g, 'blueprint') and hasattr(toolkit.g, 'view'):
+                    # Only flash success if the request has come from a blueprint view
+                    # CKAN background jobs will throw an exception
+                    toolkit.h.flash_success('DataCite DOI created')
             else:
                 same = client.check_for_update(doi.identifier, xml_dict)
                 if not same:
                     # Not the same, so we want to update the metadata
                     client.set_metadata(doi.identifier, xml_dict)
-                    toolkit.h.flash_success('DataCite DOI metadata updated')
+                    if hasattr(toolkit.g, 'blueprint') and hasattr(toolkit.g, 'view'):
+                        # Only flash success if the request has come from a blueprint view
+                        # CKAN background jobs will throw an exception
+                        toolkit.h.flash_success('DataCite DOI metadata updated')
 
         return pkg_dict
 

--- a/ckanext/doi/plugin.py
+++ b/ckanext/doi/plugin.py
@@ -89,7 +89,7 @@ class DOIPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
                 # metadata gets created before minting
                 client.set_metadata(doi.identifier, xml_dict)
                 client.mint_doi(doi.identifier, package_id)
-                if hasattr(toolkit.g, 'blueprint') and hasattr(toolkit.g, 'view'):
+                if toolkit.g and hasattr(toolkit.g, 'blueprint') and hasattr(toolkit.g, 'view'):
                     # Only flash success if the request has come from a blueprint view
                     # CKAN background jobs will throw an exception
                     toolkit.h.flash_success('DataCite DOI created')
@@ -98,7 +98,7 @@ class DOIPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
                 if not same:
                     # Not the same, so we want to update the metadata
                     client.set_metadata(doi.identifier, xml_dict)
-                    if hasattr(toolkit.g, 'blueprint') and hasattr(toolkit.g, 'view'):
+                    if toolkit.g and hasattr(toolkit.g, 'blueprint') and hasattr(toolkit.g, 'view'):
                         # Only flash success if the request has come from a blueprint view
                         # CKAN background jobs will throw an exception
                         toolkit.h.flash_success('DataCite DOI metadata updated')


### PR DESCRIPTION
The reason behind this change is to handle when CKAN background jobs update datasets (e.g. embargo releases) which trigger the `after_dataset_update` interface.
Flash messages will fail in background jobs and only work from web requests.
The solution is to check if the request has come from a blueprint view.