### PR TITLE
fix: update rightsList fields to match datacite schema

### DIFF
--- a/ckanext/doi/lib/metadata.py
+++ b/ckanext/doi/lib/metadata.py
@@ -196,7 +196,7 @@ def build_metadata_dict(pkg_dict):
             license = license_register.get(license_id)
             if license is not None:
                 optional['rightsList'] = [
-                    {'url': license.url, 'identifier': license.id}
+                    {'rightsURI': license.url, 'rightsIdentifier': license.id}
                 ]
     except Exception as e:
         errors['rightsList'] = e


### PR DESCRIPTION
updating field names "rightsURI" and "rightsIdentifier" fixes empty license information in datacites metadata

For schema 4.3 "rightsURI" will changed to "rightsUri" #101 