### PR TITLE
Strip localisation from CKAN language code for datacite metadata

### DIFF
--- a/ckanext/doi/lib/metadata.py
+++ b/ckanext/doi/lib/metadata.py
@@ -141,7 +141,9 @@ def build_metadata_dict(pkg_dict):
     # LANGUAGE
     # use language set in CKAN
     try:
-        optional['language'] = ckan_lang()
+        # remove any localisation of the language, e.g. en from en_GB.
+        # default to english in case nothing is set, because it's ckan's default
+        optional['language'] = (ckan_lang() or 'en')[:2]
     except Exception as e:
         errors['language'] = e
 


### PR DESCRIPTION
Datacite schema only accepts ISO 639-1 two-letter language codes, but CKAN has some localised versions that add more character (e.g. en_GB, pt_BR). This just strips the extra characters off the end.

As far as I can tell, the first two characters are always ISO 639-1 codes.

Also adds a default code of `en` if the language isn't set for some reason, because CKAN's default language is English.