### PR TITLE
Database initialisation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Installing from a `pyproject.toml` in editable mode (i.e. `pip install -e`) requ
    ckan.plugins = ... doi
    ```
 
-2. Initialise the database:
+2. Upgrade the database to create the tables:
    ```shell
-   ckan -c $CONFIG_FILE doi initdb
+   ckan -c $CONFIG_FILE db upgrade -p doi
    ```
 
 3. This extension will only work if you have signed up for an account with [DataCite](https://datacite.org). You will need a development/test account to use this plugin in test mode, and a live account to mint active DOIs.

--- a/ckanext/doi/cli.py
+++ b/ckanext/doi/cli.py
@@ -1,12 +1,10 @@
 import click
-from ckan import model
 from ckan.model import Session
 from ckan.plugins import toolkit
 from datacite.errors import DataCiteError
 
 from ckanext.doi.lib.api import DataciteClient
 from ckanext.doi.lib.metadata import build_metadata_dict, build_xml_dict
-from ckanext.doi.model import doi as doi_model
 from ckanext.doi.model.crud import DOIQuery
 from ckanext.doi.model.doi import DOI
 
@@ -18,21 +16,6 @@ def get_commands():
 @click.group()
 def doi():
     pass
-
-
-@doi.command(name='initdb')
-def init_db():
-    if not model.package_table.exists():
-        click.secho(
-            'Package table must exist before initialising the DOI table', fg='red'
-        )
-        raise click.Abort()
-
-    if doi_model.doi_table.exists():
-        click.secho('DOI table already exists', fg='green')
-    else:
-        doi_model.doi_table.create()
-        click.secho('DOI table created', fg='green')
 
 
 @doi.command(name='delete-dois')

--- a/ckanext/doi/migration/doi/README
+++ b/ckanext/doi/migration/doi/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/ckanext/doi/migration/doi/alembic.ini
+++ b/ckanext/doi/migration/doi/alembic.ini
@@ -1,0 +1,74 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = %(here)s
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to /base/src/ckan/ckanext-doi/ckanext/doi/migration/doi/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat /base/src/ckan/ckanext-doi/ckanext/doi/migration/doi/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/ckanext/doi/migration/doi/env.py
+++ b/ckanext/doi/migration/doi/env.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import with_statement
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+name = os.path.basename(os.path.dirname(__file__))
+
+
+def run_migrations_offline():
+    """
+    Run migrations in 'offline' mode.
+
+    This configures the context with just a URL and not an Engine, though an Engine is
+    acceptable here as well.  By skipping the Engine creation we don't even need a DBAPI
+    to be available.
+
+    Calls to context.execute() here emit the given string to the script output.
+    """
+
+    url = config.get_main_option('sqlalchemy.url')
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        version_table='{}_alembic_version'.format(name),
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """
+    Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine and associate a connection with the
+    context.
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table='{}_alembic_version'.format(name),
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/ckanext/doi/migration/doi/script.py.mako
+++ b/ckanext/doi/migration/doi/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/ckanext/doi/migration/doi/versions/86a245a136db_initialisation.py
+++ b/ckanext/doi/migration/doi/versions/86a245a136db_initialisation.py
@@ -1,0 +1,43 @@
+"""
+Initialisation.
+
+Revision ID: 86a245a136db
+Revises:
+Create Date: 2025-03-14 09:37:20.912382
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision = '86a245a136db'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # check if the table already exists
+    bind = op.get_bind()
+    insp = Inspector.from_engine(bind)
+    all_table_names = insp.get_table_names()
+    table_exists = 'doi' in all_table_names
+
+    if not table_exists:
+        op.create_table(
+            'doi',
+            sa.Column('identifier', sa.UnicodeText, primary_key=True),
+            sa.Column(
+                'package_id',
+                sa.UnicodeText,
+                sa.ForeignKey('package.id', onupdate='CASCADE', ondelete='CASCADE'),
+                nullable=False,
+                unique=True,
+            ),
+            sa.Column('published', sa.DateTime, nullable=True),
+        )
+
+
+def downgrade():
+    op.drop_table('doi')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,14 @@ import pytest
 
 from ckanext.doi.model.doi import doi_table
 
+try:
+    # 2.11 compatibility
+    from ckan.model import ensure_engine
+except ImportError:
+
+    def ensure_engine():
+        return None
+
 
 @pytest.fixture
 def with_doi_table(reset_db):
@@ -9,4 +17,5 @@ def with_doi_table(reset_db):
     Simple fixture which resets the database and creates the doi table.
     """
     reset_db()
-    doi_table.create(checkfirst=True)
+    engine = ensure_engine()
+    doi_table.create(engine, checkfirst=True)


### PR DESCRIPTION
This removes the outdated `initdb` command and introduces alembic migration scripts, which can be applied using `ckan db upgrade -p doi`. It also adds `ensure_engine` to test database initialisation.

These changes _should_ enable compatibility with CKAN 2.11, though they have not been tested with a full setup. Automated tests have been run locally using a basic image running 2.11.